### PR TITLE
/sys/class/net

### DIFF
--- a/examples/net.rs
+++ b/examples/net.rs
@@ -1,0 +1,19 @@
+extern crate sysfs_class;
+use sysfs_class::{Net, SysClass};
+use std::io;
+
+fn main() -> io::Result<()> {
+    for dev in Net::iter() {
+        let dev = dev?;
+
+        println!("{}: {}", dev.id(), dev.address().unwrap());
+        println!("    MTU: {}", dev.mtu().unwrap());
+        println!("    Duplex: {:?}", dev.duplex());
+
+        let statistics = dev.statistics();
+        println!("    RX: {} MiB", statistics.rx_bytes().unwrap() / (1024 * 1024));
+        println!("    TX: {} MiB", statistics.tx_bytes().unwrap() / (1024 * 1024));
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ mod hwmon;
 pub use leds::Leds;
 mod leds;
 
+pub use net::Net;
+mod net;
+
 pub use pci_bus::{PciDevice, PciDriver};
 mod pci_bus;
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,69 @@
+use std::io::{self, Result};
+use std::path::{Path, PathBuf};
+use SysClass;
+
+#[derive(Clone)]
+pub struct Net {
+    path: PathBuf
+}
+
+impl SysClass for Net {
+    fn class() -> &'static str {
+        "net"
+    }
+
+    unsafe fn from_path_unchecked(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Net {
+    pub fn statistics<'a>(&'a self) -> NetStatistics<'a> {
+        NetStatistics { parent: self }
+    }
+
+    method!(addr_assign_type parse_file u8);
+    method!(addr_len parse_file u16);
+    method!(address trim_file String);
+    method!(broadcast trim_file String);
+    method!(carrier parse_file u16);
+    method!(carrier_changes parse_file u16);
+    method!(carrier_down_count parse_file u16);
+    method!(carrier_up_count parse_file u16);
+    method!(dev_id trim_file String);
+    method!(dev_port parse_file u16);
+    method!(dormant parse_file u8);
+    method!(duplex trim_file String);
+    method!(mtu parse_file u32);
+    method!(operstate trim_file String);
+    method!(speed parse_file u32);
+    method!(tx_queue_len parse_file u32);
+}
+
+pub struct NetStatistics<'a> {
+    parent: &'a Net,
+}
+
+impl<'a> NetStatistics<'a> {
+    const DIR: &'static str = "statistics";
+
+    pub fn rx_bytes(&self) -> Result<u64> {
+        self.parent.parse_file(&[Self::DIR, "/rx_bytes"].concat())
+    }
+
+    pub fn rx_packets(&self) -> Result<u64> {
+        self.parent.parse_file(&[Self::DIR, "/rx_packets"].concat())
+    }
+
+    pub fn tx_bytes(&self) -> Result<u64> {
+        self.parent.parse_file(&[Self::DIR, "/tx_bytes"].concat())
+    }
+
+    pub fn tx_packets(&self) -> Result<u64> {
+        self.parent.parse_file(&[Self::DIR, "/tx_packets"].concat())
+    }
+}


### PR DESCRIPTION
```rust
extern crate sysfs_class;
use sysfs_class::{Net, SysClass};
use std::io;

fn main() -> io::Result<()> {
    for dev in Net::iter() {
        let dev = dev?;

        println!("{}: {}", dev.id());
        println!("    MTU: {}", dev.mtu().unwrap());

        let statistics = dev.statistics();
        println!("    RX:  {} MiB", statistics.rx_bytes().unwrap() / (1024 * 1024));
        println!("    TX:  {} MiB", statistics.tx_bytes().unwrap() / (1024 * 1024));
    }

    Ok(())
}
```

```
virbr0-nic
    MTU: 1500
    RX:  0 MiB
    TX:  0 MiB
enp109s0f1
    MTU: 1500
    RX:  64 MiB
    TX:  25 MiB
lo
    MTU: 65536
    RX:  2393 MiB
    TX:  2393 MiB
virbr0
    MTU: 1500
    RX:  0 MiB
    TX:  0 MiB
wlp110s0
    MTU: 1500
    RX:  312 MiB
    TX:  126 MiB
```