### PR TITLE
Extra derives for RuntimPowerManagement

### DIFF
--- a/src/runtime_pm.rs
+++ b/src/runtime_pm.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 /// Control whether a device uses, or does not use, runtime power management.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RuntimePowerManagement {
     On,
     Off,


### PR DESCRIPTION
Required for the `config` PR of system76-power