### PR TITLE
Share a Brightness trait between Backlight and LED objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 repository = "https://github.com/pop-os/sysfs-class"
 
 [dependencies]
+numtoa = "0.2.3"

--- a/examples/backlight.rs
+++ b/examples/backlight.rs
@@ -1,5 +1,5 @@
 extern crate sysfs_class;
-use sysfs_class::{Backlight, SysClass};
+use sysfs_class::{Backlight, Brightness, SysClass};
 use std::io;
 
 fn main() -> io::Result<()> {

--- a/examples/leds.rs
+++ b/examples/leds.rs
@@ -1,5 +1,5 @@
 extern crate sysfs_class;
-use sysfs_class::{Leds, SysClass};
+use sysfs_class::{Brightness, Leds, SysClass};
 use std::io;
 
 fn main() -> io::Result<()> {

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Result};
+use std::io::Result;
 use std::path::{Path, PathBuf};
-use SysClass;
+use {Brightness, SysClass};
 
 /// Fetch and modify brightness values of backlight controls.
 #[derive(Clone)]
@@ -27,25 +27,7 @@ impl Backlight {
 
     method!(bl_power parse_file u64);
 
-    method!(brightness parse_file u64);
-    set_method!("brightness", set_brightness u64);
-
-    method!(max_brightness parse_file u64);
-
     method!("type", type_ trim_file String);
-
-    /// Sets the `new` brightness level if it is less than the current brightness.
-    ///
-    /// Returns the brightness level that was set at the time of exiting the function.
-    pub fn set_if_lower(&mut self, new: u64) -> io::Result<u64> {
-        let max_brightness = self.max_brightness()?;
-        let current = self.brightness()?;
-        let new = max_brightness * new / 100;
-        if new < current {
-            self.set_brightness(new)?;
-            Ok(new)
-        } else {
-            Ok(current)
-        }
-    }
 }
+
+impl Brightness for Backlight {}

--- a/src/brightness.rs
+++ b/src/brightness.rs
@@ -1,0 +1,25 @@
+use std::io::Result;
+use SysClass;
+
+pub trait Brightness: SysClass {
+    trait_method!(brightness parse_file u64);
+
+    trait_method!(max_brightness parse_file u64);
+
+    set_trait_method!("brightness", set_brightness u64);
+
+    /// Sets the `new` brightness level if it is less than the current brightness.
+    ///
+    /// Returns the brightness level that was set at the time of exiting the function.
+    fn set_if_lower_than(&self, percent: u64) -> Result<()> {
+        let max_brightness = self.max_brightness()?;
+        let current = self.brightness()?;
+
+        let new = max_brightness * percent / 100;
+        if new < current {
+            self.set_brightness(new)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Result};
+use std::io::Result;
 use std::path::{Path, PathBuf};
-use SysClass;
+use {Brightness, SysClass};
 
 /// Fetch and modify brightness values of LED controllers.
 #[derive(Clone)]
@@ -23,30 +23,12 @@ impl SysClass for Leds {
 }
 
 impl Leds {
-    method!(brightness parse_file u64);
-    set_method!("brightness", set_brightness u64);
-
-    method!(max_brightness parse_file u64);
-
-    /// Sets the `new` brightness level if it is less than the current brightness.
-    ///
-    /// Returns the brightness level that was set at the time of exiting the function.
-    pub fn set_if_lower(&mut self, new: u64) -> io::Result<u64> {
-        let max_brightness = self.max_brightness()?;
-        let current = self.brightness()?;
-        let new = max_brightness * new / 100;
-        if new < current {
-            self.set_brightness(new)?;
-            Ok(new)
-        } else {
-            Ok(current)
-        }
-    }
-
     /// Filters backlights to only include keyboard backlights
-    pub fn keyboard_backlights() -> Box<Iterator<Item = Result<Self>>> where Self: 'static {
-        Box::new(Self::iter().filter(|object| {
+    pub fn iter_keyboards() -> impl Iterator<Item = Result<Self>> where Self: 'static {
+        Self::iter().filter(move |object| {
             object.as_ref().ok().map_or(true, |o| o.id().contains("kbd_backlight"))
-        }))
+        })
     }
 }
+
+impl Brightness for Leds {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,14 @@
+extern crate numtoa;
+
 pub use sys_class::SysClass;
 #[macro_use]
 mod sys_class;
 
 pub use backlight::Backlight;
 mod backlight;
+
+pub use brightness::Brightness;
+mod brightness;
 
 pub use block::Block;
 mod block;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Result};
+use std::io::Result;
 use std::path::{Path, PathBuf};
 use SysClass;
 
@@ -22,7 +22,7 @@ impl SysClass for Net {
 }
 
 impl Net {
-    pub fn statistics<'a>(&'a self) -> NetStatistics<'a> {
+    pub fn statistics(&self) -> NetStatistics {
         NetStatistics { parent: self }
     }
 

--- a/src/pci_bus/mod.rs
+++ b/src/pci_bus/mod.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{self, Result};
+use std::io;
 use std::path::{Path, PathBuf};
 use SysClass;
 use RuntimePM;

--- a/src/sys_class.rs
+++ b/src/sys_class.rs
@@ -20,15 +20,49 @@ macro_rules! method {
 }
 
 #[macro_export]
+macro_rules! trait_method {
+    ($file:tt $with:tt $out:tt) => {
+        fn $file(&self) -> Result<$out> {
+            self.$with(stringify!($file))
+        }
+    };
+
+    ($file:expr, $method:tt $with:tt $out:tt) => {
+        fn $method(&self) -> Result<$out> {
+            self.$with($file)
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! set_method {
     ($file:expr, $method:tt $with:ty) => {
         pub fn $method(&self, input: $with) -> Result<()> {
-            self.write_file($file, format!("{}", input))
+            use numtoa::NumToA;
+            let mut buf = [0u8; 20];
+            self.write_file($file, input.numtoa_str(10, &mut buf))
         }
     };
 
     ($file:expr, $method:tt) => {
         pub fn $method<B: AsRef<[u8]>>(&self, input: B) -> Result<()> {
+            self.write_file($file, input.as_ref())
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! set_trait_method {
+    ($file:expr, $method:tt $with:ty) => {
+        fn $method(&self, input: $with) -> Result<()> {
+            use numtoa::NumToA;
+            let mut buf = [0u8; 20];
+            self.write_file($file, input.numtoa_str(10, &mut buf))
+        }
+    };
+
+    ($file:expr, $method:tt) => {
+        fn $method<B: AsRef<[u8]>>(&self, input: B) -> Result<()> {
             self.write_file($file, input.as_ref())
         }
     };


### PR DESCRIPTION
This will be useful in system76-power for handling screen and keyboard backlights generically with the same underlying brightness trait.