### PR TITLE
Move to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sysfs-class"
 version = "0.1.2"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
+edition = "2018"
 description = "Rust library for viewing /sys/class in an object-oriented format"
 license = "MIT"
 repository = "https://github.com/pop-os/sysfs-class"

--- a/examples/backlight.rs
+++ b/examples/backlight.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{Backlight, Brightness, SysClass};
 use std::io;
+use sysfs_class::{Backlight, Brightness, SysClass};
 
 fn main() -> io::Result<()> {
     for dev in Backlight::all()? {

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{Block, SysClass};
 use std::io;
+use sysfs_class::{Block, SysClass};
 
 fn main() -> io::Result<()> {
     for block in Block::all()? {

--- a/examples/dmi.rs
+++ b/examples/dmi.rs
@@ -1,4 +1,3 @@
-extern crate sysfs_class;
 use sysfs_class::DmiId;
 
 fn main() {

--- a/examples/leds.rs
+++ b/examples/leds.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{Brightness, Leds, SysClass};
 use std::io;
+use sysfs_class::{Brightness, Leds, SysClass};
 
 fn main() -> io::Result<()> {
     for dev in Leds::all()? {

--- a/examples/net.rs
+++ b/examples/net.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{Net, SysClass};
 use std::io;
+use sysfs_class::{Net, SysClass};
 
 fn main() -> io::Result<()> {
     for dev in Net::iter() {
@@ -11,8 +10,14 @@ fn main() -> io::Result<()> {
         println!("    Duplex: {:?}", dev.duplex());
 
         let statistics = dev.statistics();
-        println!("    RX: {} MiB", statistics.rx_bytes().unwrap() / (1024 * 1024));
-        println!("    TX: {} MiB", statistics.tx_bytes().unwrap() / (1024 * 1024));
+        println!(
+            "    RX: {} MiB",
+            statistics.rx_bytes().unwrap() / (1024 * 1024)
+        );
+        println!(
+            "    TX: {} MiB",
+            statistics.tx_bytes().unwrap() / (1024 * 1024)
+        );
     }
 
     Ok(())

--- a/examples/pci.rs
+++ b/examples/pci.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{PciDevice, PciDriver, SysClass};
 use std::io;
+use sysfs_class::{PciDevice, PciDriver, SysClass};
 
 fn main() -> io::Result<()> {
     for dev in PciDevice::all()? {

--- a/examples/scsi_host.rs
+++ b/examples/scsi_host.rs
@@ -1,6 +1,5 @@
-extern crate sysfs_class;
-use sysfs_class::{ScsiHost, SysClass};
 use std::io;
+use sysfs_class::{ScsiHost, SysClass};
 
 fn main() -> io::Result<()> {
     for host in ScsiHost::all()? {

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -1,11 +1,11 @@
+use crate::{Brightness, SysClass};
 use std::io::Result;
 use std::path::{Path, PathBuf};
-use {Brightness, SysClass};
 
 /// Fetch and modify brightness values of backlight controls.
 #[derive(Clone)]
 pub struct Backlight {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for Backlight {

--- a/src/block.rs
+++ b/src/block.rs
@@ -2,7 +2,7 @@ use crate::SysClass;
 use std::io::Result;
 use std::path::{Path, PathBuf};
 
-pub type SlaveIter = Box<Iterator<Item = Result<PathBuf>>>;
+pub type SlaveIter = Box<dyn Iterator<Item = Result<PathBuf>>>;
 
 /// A block device in /sys/class/block
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,14 +1,13 @@
+use crate::SysClass;
 use std::io::Result;
 use std::path::{Path, PathBuf};
-
-use SysClass;
 
 pub type SlaveIter = Box<Iterator<Item = Result<PathBuf>>>;
 
 /// A block device in /sys/class/block
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Block {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for Block {
@@ -31,9 +30,11 @@ impl Block {
     }
 
     pub fn children(&self) -> Result<Vec<Self>> {
-        let mut children = Block::all()?.into_iter()
+        let mut children = Block::all()?
+            .into_iter()
             .filter(|x| {
-                x.parent_device().map_or(false, |parent| parent.path() == self.path)
+                x.parent_device()
+                    .map_or(false, |parent| parent.path() == self.path)
             })
             .collect::<Vec<_>>();
         children.sort_unstable();
@@ -61,7 +62,7 @@ impl Block {
         if slaves_path.exists() {
             let res: Result<SlaveIter> = match slaves_path.read_dir() {
                 Ok(iter) => Ok(Box::new(iter.map(|entry| Ok(entry?.path())))),
-                Err(why) => Err(why)
+                Err(why) => Err(why),
             };
 
             Some(res)
@@ -197,7 +198,7 @@ impl Block {
         for schedule in self.read_file("queue/scheduler")?.split_whitespace() {
             let schedule = if schedule.starts_with('[') {
                 active = schedules.len();
-                &schedule[1..schedule.len()-1]
+                &schedule[1..schedule.len() - 1]
             } else {
                 schedule
             };
@@ -205,7 +206,10 @@ impl Block {
             schedules.push(schedule.to_owned());
         }
 
-        Ok(BlockScheduler { active: active as u8, schedules })
+        Ok(BlockScheduler {
+            active: active as u8,
+            schedules,
+        })
     }
 
     method!("queue/write_cache", queue_write_cache read_file String);
@@ -255,7 +259,7 @@ impl Block {
 
 pub struct BlockScheduler {
     schedules: Vec<String>,
-    active: u8
+    active: u8,
 }
 
 impl BlockScheduler {

--- a/src/brightness.rs
+++ b/src/brightness.rs
@@ -1,5 +1,5 @@
+use crate::SysClass;
 use std::io::Result;
-use SysClass;
 
 pub trait Brightness: SysClass {
     trait_method!(brightness parse_file u64);

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,19 +1,20 @@
+use crate::SysClass;
 use std::io::Result;
 use std::path::{Path, PathBuf};
 
 const BASE_PATH: &str = "/sys/class/dmi/id";
 
-use SysClass;
-
 /// Provides BIOS, Board, Chassis, Product, & Vendor identifiers
 #[derive(Clone)]
 pub struct DmiId {
-    path: &'static Path
+    path: &'static Path,
 }
 
 impl Default for DmiId {
     fn default() -> Self {
-        Self { path: Path::new(BASE_PATH) }
+        Self {
+            path: Path::new(BASE_PATH),
+        }
     }
 }
 
@@ -39,7 +40,7 @@ impl DmiId {
     method!(bios_version read_file String);
 
     method!(board_asset_tag read_file String);
-    
+
     method!(board_name read_file String);
 
     method!(board_serial read_file String);
@@ -49,7 +50,7 @@ impl DmiId {
     method!(board_version read_file String);
 
     method!(chassis_asset_tag read_file String);
-    
+
     method!(chassis_name read_file String);
 
     method!(chassis_serial read_file String);
@@ -74,4 +75,3 @@ impl DmiId {
 
     method!(sys_vendor read_file String);
 }
-

--- a/src/hwmon/fan.rs
+++ b/src/hwmon/fan.rs
@@ -1,6 +1,5 @@
+use crate::{HwMon, SysClass};
 use std::io::Result;
-
-use {HwMon, SysClass};
 
 pub struct HwMonFan<'a> {
     hwmon: &'a HwMon,
@@ -9,10 +8,7 @@ pub struct HwMonFan<'a> {
 
 impl<'a> HwMonFan<'a> {
     pub fn new(hwmon: &'a HwMon, id: u64) -> Result<Self> {
-        let s = Self {
-            hwmon,
-            id
-        };
+        let s = Self { hwmon, id };
 
         s.input()?;
 

--- a/src/hwmon/mod.rs
+++ b/src/hwmon/mod.rs
@@ -1,7 +1,6 @@
+use crate::SysClass;
 use std::io::Result;
 use std::path::{Path, PathBuf};
-
-use SysClass;
 
 pub use self::fan::HwMonFan;
 mod fan;

--- a/src/hwmon/pwm.rs
+++ b/src/hwmon/pwm.rs
@@ -1,6 +1,5 @@
+use crate::{HwMon, SysClass};
 use std::io::Result;
-
-use {HwMon, SysClass};
 
 pub struct HwMonPwm<'a> {
     hwmon: &'a HwMon,
@@ -9,10 +8,7 @@ pub struct HwMonPwm<'a> {
 
 impl<'a> HwMonPwm<'a> {
     pub fn new(hwmon: &'a HwMon, id: u64) -> Result<Self> {
-        let s = Self {
-            hwmon,
-            id
-        };
+        let s = Self { hwmon, id };
 
         s.input()?;
 

--- a/src/hwmon/temp.rs
+++ b/src/hwmon/temp.rs
@@ -1,6 +1,5 @@
+use crate::{HwMon, SysClass};
 use std::io::Result;
-
-use {HwMon, SysClass};
 
 pub struct HwMonTemp<'a> {
     hwmon: &'a HwMon,
@@ -9,10 +8,7 @@ pub struct HwMonTemp<'a> {
 
 impl<'a> HwMonTemp<'a> {
     pub fn new(hwmon: &'a HwMon, id: u64) -> Result<Self> {
-        let s = Self {
-            hwmon,
-            id
-        };
+        let s = Self { hwmon, id };
 
         s.input()?;
 

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,11 +1,11 @@
+use crate::{Brightness, SysClass};
 use std::io::Result;
 use std::path::{Path, PathBuf};
-use {Brightness, SysClass};
 
 /// Fetch and modify brightness values of LED controllers.
 #[derive(Clone)]
 pub struct Leds {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for Leds {
@@ -24,9 +24,15 @@ impl SysClass for Leds {
 
 impl Leds {
     /// Filters backlights to only include keyboard backlights
-    pub fn iter_keyboards() -> impl Iterator<Item = Result<Self>> where Self: 'static {
+    pub fn iter_keyboards() -> impl Iterator<Item = Result<Self>>
+    where
+        Self: 'static,
+    {
         Self::iter().filter(move |object| {
-            object.as_ref().ok().map_or(true, |o| o.id().contains("kbd_backlight"))
+            object
+                .as_ref()
+                .ok()
+                .map_or(true, |o| o.id().contains("kbd_backlight"))
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,33 @@
-extern crate numtoa;
-
-pub use sys_class::SysClass;
+pub use crate::sys_class::SysClass;
 #[macro_use]
 mod sys_class;
 
-pub use backlight::Backlight;
+pub use crate::backlight::Backlight;
 mod backlight;
 
-pub use brightness::Brightness;
+pub use crate::brightness::Brightness;
 mod brightness;
 
-pub use block::Block;
+pub use crate::block::Block;
 mod block;
 
-pub use dmi::DmiId;
+pub use crate::dmi::DmiId;
 mod dmi;
 
-pub use hwmon::{HwMon, HwMonFan, HwMonPwm, HwMonTemp};
+pub use crate::hwmon::{HwMon, HwMonFan, HwMonPwm, HwMonTemp};
 mod hwmon;
 
-pub use leds::Leds;
+pub use crate::leds::Leds;
 mod leds;
 
-pub use net::Net;
+pub use crate::net::Net;
 mod net;
 
-pub use pci_bus::{PciDevice, PciDriver};
+pub use crate::pci_bus::{PciDevice, PciDriver};
 mod pci_bus;
 
-pub use runtime_pm::{RuntimePM, RuntimePowerManagement};
+pub use crate::runtime_pm::{RuntimePM, RuntimePowerManagement};
 mod runtime_pm;
 
-pub use scsi_host::ScsiHost;
+pub use crate::scsi_host::ScsiHost;
 mod scsi_host;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,10 +1,10 @@
+use crate::SysClass;
 use std::io::Result;
 use std::path::{Path, PathBuf};
-use SysClass;
 
 #[derive(Clone)]
 pub struct Net {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for Net {

--- a/src/pci_bus/mod.rs
+++ b/src/pci_bus/mod.rs
@@ -1,13 +1,11 @@
+use crate::{RuntimePM, RuntimePowerManagement, SysClass};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use SysClass;
-use RuntimePM;
-use RuntimePowerManagement;
 
 #[derive(Clone)]
 pub struct PciDriver {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for PciDriver {
@@ -56,7 +54,7 @@ macro_rules! pci_devices {
 
 #[derive(Clone)]
 pub struct PciDevice {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for PciDevice {
@@ -88,8 +86,7 @@ impl PciDevice {
     }
 
     pub fn driver(&self) -> io::Result<PciDriver> {
-        fs::canonicalize(self.path.join("driver"))
-            .map(|path| PciDriver { path })
+        fs::canonicalize(self.path.join("driver")).map(|path| PciDriver { path })
     }
 
     pub unsafe fn remove(&self) -> io::Result<()> {

--- a/src/scsi_host.rs
+++ b/src/scsi_host.rs
@@ -1,11 +1,11 @@
+use crate::SysClass;
 use std::io::{self, Result};
 use std::path::{Path, PathBuf};
-use SysClass;
 
 /// Fetch and modify SCSI host parameters.
 #[derive(Clone)]
 pub struct ScsiHost {
-    path: PathBuf
+    path: PathBuf,
 }
 
 impl SysClass for ScsiHost {
@@ -34,8 +34,14 @@ impl ScsiHost {
     /// Sets the power management profile for this SCSI host.
     ///
     /// Multiple profiles are given, and each profile is tried until one succeeds.
-    pub fn set_link_power_management_policy<'b>(&self, profiles: &[&'b str]) -> io::Result<&'b str> {
-        debug_assert!(!profiles.is_empty(), "at least one profile must be specified");
+    pub fn set_link_power_management_policy<'b>(
+        &self,
+        profiles: &[&'b str],
+    ) -> io::Result<&'b str> {
+        debug_assert!(
+            !profiles.is_empty(),
+            "at least one profile must be specified"
+        );
 
         let mut last_result = Ok(());
         let mut last_prof = "";
@@ -44,7 +50,7 @@ impl ScsiHost {
             last_result = self.write_file("link_power_management_policy", prof);
             last_prof = prof;
             if last_result.is_ok() {
-                break
+                break;
             }
         }
 

--- a/src/sys_class.rs
+++ b/src/sys_class.rs
@@ -90,16 +90,18 @@ pub trait SysClass: Sized {
     /// Create a sys object from a path, checking it for validity
     fn from_path(path: &Path) -> Result<Self> {
         {
-            let parent = path.parent().ok_or_else(|| Error::new(
-                ErrorKind::InvalidInput,
-                format!("{}: does not have parent", path.display())
-            ))?;
+            let parent = path.parent().ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("{}: does not have parent", path.display()),
+                )
+            })?;
 
             let dir = Self::dir();
             if parent != dir {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("{}: is not a child of {}", path.display(), dir.display())
+                    format!("{}: is not a child of {}", path.display(), dir.display()),
                 ));
             }
         }
@@ -122,14 +124,15 @@ pub trait SysClass: Sized {
     }
 
     /// Retrieve all of the object instances of a sys class, with a boxed iterator
-    fn iter() -> Box<Iterator<Item = Result<Self>>> where Self: 'static {
+    fn iter() -> Box<Iterator<Item = Result<Self>>>
+    where
+        Self: 'static,
+    {
         match fs::read_dir(Self::dir()) {
             Ok(entries) => Box::new(
-                entries.map(|entry_res| entry_res.and_then(|entry| {
-                    Self::from_path(&entry.path())
-                }))
+                entries.map(|entry_res| entry_res.and_then(|entry| Self::from_path(&entry.path()))),
             ),
-            Err(why) => Box::new(::std::iter::once(Err(why)))
+            Err(why) => Box::new(::std::iter::once(Err(why))),
         }
     }
 
@@ -141,8 +144,10 @@ pub trait SysClass: Sized {
     /// Return the id of the sys object
     fn id(&self) -> &str {
         self.path()
-            .file_name().unwrap() // A valid path does not end in .., so safe
-            .to_str().unwrap() // A valid path must be valid UTF-8, so safe
+            .file_name()
+            .unwrap() // A valid path does not end in .., so safe
+            .to_str()
+            .unwrap() // A valid path must be valid UTF-8, so safe
     }
 
     /// Read a file underneath the sys object
@@ -159,13 +164,19 @@ pub trait SysClass: Sized {
     }
 
     /// Parse a number from a file underneath the sys object
-    fn parse_file<F: FromStr, P: AsRef<Path>>(&self, name: P) -> Result<F> where F::Err: Display {
-        self.read_file(name.as_ref())?.trim().parse().map_err(|err| {
-            Error::new(
-                ErrorKind::InvalidData,
-                format!("{}: {}", name.as_ref().display(), err)
-            )
-        })
+    fn parse_file<F: FromStr, P: AsRef<Path>>(&self, name: P) -> Result<F>
+    where
+        F::Err: Display,
+    {
+        self.read_file(name.as_ref())?
+            .trim()
+            .parse()
+            .map_err(|err| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("{}: {}", name.as_ref().display(), err),
+                )
+            })
     }
 
     /// Read a file underneath the sys object and trim whitespace

--- a/src/sys_class.rs
+++ b/src/sys_class.rs
@@ -124,7 +124,7 @@ pub trait SysClass: Sized {
     }
 
     /// Retrieve all of the object instances of a sys class, with a boxed iterator
-    fn iter() -> Box<Iterator<Item = Result<Self>>>
+    fn iter() -> Box<dyn Iterator<Item = Result<Self>>>
     where
         Self: 'static,
     {


### PR DESCRIPTION
This PR updates the crate to the 2018 edition, runs rustfmt across the codebase and fixes the bare trait objects warning.