### PR TITLE
Make all temperature values signed to allow temperatures below 0°C

### DIFF
--- a/src/hwmon/temp.rs
+++ b/src/hwmon/temp.rs
@@ -19,27 +19,27 @@ impl<'a> HwMonTemp<'a> {
         self.hwmon.trim_file(&format!("temp{}_label", self.id))
     }
 
-    pub fn input(&self) -> Result<u32> {
+    pub fn input(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_input", self.id))
     }
 
-    pub fn lcrit(&self) -> Result<u32> {
+    pub fn lcrit(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_lcrit", self.id))
     }
 
-    pub fn min(&self) -> Result<u32> {
+    pub fn min(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_min", self.id))
     }
 
-    pub fn max(&self) -> Result<u32> {
+    pub fn max(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_max", self.id))
     }
 
-    pub fn crit(&self) -> Result<u32> {
+    pub fn crit(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_crit", self.id))
     }
 
-    pub fn emergency(&self) -> Result<u32> {
+    pub fn emergency(&self) -> Result<i32> {
         self.hwmon.parse_file(&format!("temp{}_emergency", self.id))
     }
 }


### PR DESCRIPTION
Hi,

I am using this crate to keep track of the enclosure-temperature in an outdoor project and noticed that it started randomly crashing in the recent months, mostly at night.
Tracking it down to the temperature going down below 0°C, resulting in a failure parsing it as an u32 was a fun little rabbit hole.